### PR TITLE
Mark bde_get_app_specific and bde_get_combined_appellation as STABLE

### DIFF
--- a/sql/03-bde_functions.sql.in
+++ b/sql/03-bde_functions.sql.in
@@ -188,7 +188,7 @@ BEGIN
 
     RETURN v_app_text;
 END;
-    $$ LANGUAGE plpgsql STRICT;
+    $$ LANGUAGE plpgsql STABLE STRICT;
 
 ALTER FUNCTION bde_get_app_specific(INTEGER, VARCHAR, CHAR) OWNER TO bde_dba;
 REVOKE ALL ON FUNCTION bde_get_app_specific(INTEGER, VARCHAR, CHAR) FROM PUBLIC;
@@ -764,7 +764,7 @@ BEGIN
 
     RETURN v_appellation;
 END;
-    $$ LANGUAGE plpgsql VOLATILE STRICT;
+    $$ LANGUAGE plpgsql STABLE STRICT;
 
 ALTER FUNCTION bde_get_combined_appellation(INTEGER, CHAR) OWNER TO bde_dba;
 REVOKE ALL ON FUNCTION bde_get_combined_appellation(INTEGER, CHAR) FROM PUBLIC;


### PR DESCRIPTION
VOLATILE, as they are currently created, is for functions that can
change return even within a single table scan (ie: db editing
functions or those that depend on state outside the db).

Hopefully gives the optimizer more chances of reducing calls.