### PR TITLE
Embed full version in function descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,8 @@ EXTRA_CLEAN = sql/05-bde_version.sql sql/03-bde_functions.sql
 
 all: $(SQLSCRIPTS)
 
-sql/05-bde_version.sql: sql/05-bde_version.sql.in
-	$(SED) -e 's/@@VERSION@@/$(VERSION)/' $< > $@
-
-sql/03-bde_functions.sql: sql/03-bde_functions.sql.in Makefile
-	$(SED) -e 's/\$$Id\$$/$(REVISION)/' $< > $@
+%.sql: %.sql.in Makefile
+	$(SED) -e 's/@@VERSION@@/$(VERSION)/;s/@@REVISION@@/$(REVISION)/' $< > $@
 
 install: $(SQLSCRIPTS)
 	mkdir -p ${datadir}/sql

--- a/sql/03-bde_functions.sql.in
+++ b/sql/03-bde_functions.sql.in
@@ -1003,7 +1003,7 @@ BEGIN
             v_comment := E'\n\n' || v_comment;
         END IF;
 
-        v_comment := '$Id$'
+        v_comment := 'Version: @@VERSION@@ @@REVISION@@'
                     || E'\n' || 'Installed: ' ||
                     to_char(current_timestamp,'YYYY-MM-DD HH:MI') || v_comment;
 


### PR DESCRIPTION
This is to match lds-bde-schema and schema installed by bde-uploader