### PR TITLE
Add support for BDESCHEMA_SQLDIR and install script in /usr, not /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REVISION = $(shell test -d .git && git describe --always || echo $(VERSION))
 SED = sed
 
 datadir=${DESTDIR}/usr/share/linz-bde-schema
-bindir=${DESTDIR}/usr/local/bin
+bindir=${DESTDIR}/usr/bin
 
 #
 # Uncoment these line to support testing via pg_regress

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ to the `linz-bde-schema-load` invocation:
 ```shell
 linz-bde-schema-load --noindexes --revision $DB_NAME
 ```
+
+NOTE: the loader script will expect to find SQL scripts
+      under `/usr/share/linz-bde-schema/sql`, if you want
+      them found in a different directory you can set the
+      ``BDESCHEMA_SQLDIR`` environment variable.
+
+
 Upgrade
 -------
 

--- a/scripts/linz-bde-schema-load
+++ b/scripts/linz-bde-schema-load
@@ -6,6 +6,10 @@ export ADD_REVISIONS=no
 export PSQL=psql
 export SCRIPTSDIR=/usr/share/linz-bde-schema/sql/
 
+if test -n "${BDESCHEMA_SQLDIR}"; then
+    SCRIPTSDIR=${BDESCHEMA_SQLDIR}
+fi
+
 while test -n "$1"; do
     if test $1 = "--noindexes"; then
         SKIP_INDEXES=yes


### PR DESCRIPTION
SQL files are installed in /usr/share by default,
not /usr/local/share. With this commit the `linz-bde-schema-load`
script will also be installed in `/usr/bin` rather than `/usr/local/bin`.

Also, it will support custom SQL files directory via BDESCHEMA_SQLDIR env variable