### PR TITLE
Do not give SUPERUSER privileges to "bde_dba" role

### DIFF
--- a/sql/01-bde_roles.sql
+++ b/sql/01-bde_roles.sql
@@ -17,7 +17,7 @@ BEGIN
 
 IF NOT EXISTS (SELECT * FROM pg_roles where rolname = 'bde_dba') THEN
     CREATE ROLE bde_dba
-        SUPERUSER INHERIT CREATEDB CREATEROLE;
+        NOSUPERUSER INHERIT CREATEDB CREATEROLE;
     ALTER ROLE bde_dba SET search_path=bde, bde_control, public;
 END IF;
 


### PR DESCRIPTION
Allows loading bde-schema in database systems where no SUPERUSER
privilege is available (ie: AWS RDS).

Closes #47