### PR TITLE
Drop explicit dependency of binary package on postgresql

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,11 +11,9 @@ Vcs-Browser: https://github.com/linz/linz-bde-schema.git
 
 Package: linz-bde-schema
 Architecture: all
-Depends: ${misc:Depends},
-         postgresql-9.3,
-         postgresql-9.3-postgis-2.1|postgresql-9.3-postgis-2.2,
-         postgresql-9.3-dbpatch
-Recommends: postgresql-9.3-tableversion
+Depends: ${misc:Depends}
+Recommends: postgresql-9.3-tableversion (>= 1.4.0),
+         postgresql-9.3-dbpatch (>= 1.2.0)
 Description: Provides the core BDE schemas and functions that are used
  for storing and accessing raw BDE unloads from the Landonline database
  system.


### PR DESCRIPTION
The schema can be installed in a remote database so there's no need
to have one locally.

Dependency on dbpatch and tableversion is made "recommended" because
it is only needed for the loader script and only for finding their
own loader scripts (currently in the same package as the PostgreSQL
side, unfortunately). For this reason specific versions are
recommended (those that do provide the loader scripts)

Closes #55