### PR TITLE
Grant loading user "bde_dba" role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes for the LINZ BDE schema are documented in this file.
 
 ## 1.1.2dev - 2017-12-DD
+### Fixed
+- Ability to enable schema for non-superuser (#72)
+  ( loading user is granted `bde_dba` role )
 
 ## 1.1.1 - 2017-12-11
 ### Enhanced

--- a/sql/01-bde_roles.sql
+++ b/sql/01-bde_roles.sql
@@ -24,6 +24,16 @@ COMMENT ON ROLE bde_dba IS $COMMENT$
 'Owns all objects in bde schema. Has rights to manage all of them.'
 $COMMENT$;
 
+-- User loading this script must be part of the `bde_dba` team
+-- in order to be able to give ownerhip of created objects
+-- to it, instead of getting a message like:
+--
+--   ERROR:  must be member of role "testrole"
+--
+-- See https://github.com/linz/linz-bde-schema/issues/71
+--
+EXECUTE 'GRANT bde_dba TO ' || quote_ident(current_user);
+
 IF NOT EXISTS (SELECT * FROM pg_roles where rolname = 'bde_admin') THEN
     CREATE ROLE bde_admin
         NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;


### PR DESCRIPTION
A user with GRANT USER option is not automatically made part
of the role she creates, which prevents later transferring
ownership of created objects to that role.

Closes #71