### PR TITLE
Limit bde function drop to those whose name starts in 'bde_'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes for the LINZ BDE schema are documented in this file.
 
 ## 1.2.0dev - YYYY-MM-DD
 - Have loader create postgis extension in the public schema (#83)
+- Do not try to drop functions in bde schema whose name
+  does not start in `bde_` (#81)
 
 ## 1.1.2 - 2017-12-20
 ### Fixed

--- a/sql/03-bde_functions.sql.in
+++ b/sql/03-bde_functions.sql.in
@@ -24,6 +24,7 @@ BEGIN
         SELECT v_schema || '.' || proname || '(' || pg_get_function_identity_arguments(oid) || ')'
         FROM pg_proc
         WHERE pronamespace=(SELECT oid FROM pg_namespace WHERE nspname = v_schema)
+          AND proname like 'bde_%'
     LOOP
         EXECUTE 'DROP FUNCTION ' || v_pcid;
     END LOOP;


### PR DESCRIPTION
Reduces risk of dropping unrelated functions accidentally
installed in the 'bde' schema
(ie: https://github.com/linz/linz-lds-bde-schema/issues/79)

Closes #81