### PR TITLE
[debian] Drop postgesql-server-dev-9.3 build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: linz-bde-schema
 Section: database
 Priority: extra
-Build-Depends: debhelper (>= 7),
-               postgresql-server-dev-9.3
+Build-Depends: debhelper (>= 7)
 Standards-Version: 3.9.5
 Maintainer: Jeremy Palmer (LINZ) <jpalmer@linz.govt.nz>
 Homepage: http://www.linz.govt.nz


### PR DESCRIPTION
There's no real dependency on that package