### PR TITLE
Make schema loader less noisy

### DIFF
--- a/scripts/linz-bde-schema-load.in
+++ b/scripts/linz-bde-schema-load.in
@@ -91,6 +91,7 @@ fi
 
 (
 cat << EOF
+SET client_min_messages TO WARNING;
 CREATE EXTENSION IF NOT EXISTS postgis SCHEMA public;
 EOF
 
@@ -108,4 +109,4 @@ if test "${ADD_REVISIONS}" = "yes"; then
     cat ${file} || exit 1
 fi
 
-) | $PSQL -tA --set ON_ERROR_STOP=1
+) | $PSQL -tA --set ON_ERROR_STOP=1 > /dev/null


### PR DESCRIPTION
Sets client min messages to WARNING and filters out operation
confirmations (COMMENT,CREATE,DO etc.)