### PR TITLE
Add upgrade testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,3 +98,5 @@ script:
   # Test build and installation of debian package
   - make deb
   - sudo dpkg -i ../linz-bde-schema*.deb
+  # Test upgrades
+  - test/test-upgrades.sh

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,15 @@ install: $(SQLSCRIPTS) $(SCRIPTS_built)
 
 installcheck: check-loader
 
+# Check an already prepared database
+# It is expected that the prepared database
+# is set via PGDATABASE
+check-prepared:
+	V=`psql -XtAc 'select bde.bde_version()'` && \
+	echo $$V && test "$$V" = "$(VERSION)" && \
+	V=`linz-bde-schema-load --version` && \
+	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+
 # TODO: run the full test after preparing the db ?
 check-loader:
 
@@ -68,30 +77,21 @@ check-loader:
 	linz-bde-schema-load linz-bde-schema-test-db
 	linz-bde-schema-load linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 	createdb linz-bde-schema-test-db
 	linz-bde-schema-load --noextension linz-bde-schema-test-db
 	linz-bde-schema-load --noextension linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 	createdb linz-bde-schema-test-db
 	linz-bde-schema-load --revision linz-bde-schema-test-db
 	linz-bde-schema-load --revision linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 # TODO: run the full test after preparing the db ?
@@ -105,10 +105,7 @@ check-loader-stdout:
 	linz-bde-schema-load - | \
         psql -Xo /dev/null linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 	createdb linz-bde-schema-test-db
@@ -117,10 +114,7 @@ check-loader-stdout:
 	linz-bde-schema-load --noextension - | \
         psql -Xo /dev/null linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 	createdb linz-bde-schema-test-db
@@ -129,10 +123,7 @@ check-loader-stdout:
 	linz-bde-schema-load --revision - | \
         psql -Xo /dev/null linz-bde-schema-test-db
 	export PGDATABASE=linz-bde-schema-test-db; \
-	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
-	V=`linz-bde-schema-load --version` && \
-	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
+	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,17 @@ installcheck: check-loader
 # Check an already prepared database
 # It is expected that the prepared database
 # is set via PGDATABASE
+#
+# TODO: run the full set of test
+#
 check-prepared:
 	V=`psql -XtAc 'select bde.bde_version()'` && \
-	echo $$V && test "$$V" = "$(VERSION)" && \
+	echo $$V && test "$$V" = "$(VERSION)"
+
+check-loader:
+
 	V=`linz-bde-schema-load --version` && \
 	echo $$V && test `echo "$$V" | awk '{print $$1}'` = "$(VERSION)"
-
-# TODO: run the full test after preparing the db ?
-check-loader:
 
 	dropdb --if-exists linz-bde-schema-test-db
 
@@ -94,7 +97,6 @@ check-loader:
 	$(MAKE) check-prepared
 	dropdb linz-bde-schema-test-db
 
-# TODO: run the full test after preparing the db ?
 check-loader-stdout:
 
 	dropdb --if-exists linz-bde-schema-test-db

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ on the target database system,
 [dbpatch](https://github.com/linz/postgresql-dbpatch)
 version 1.2.0 or higher and optionally
 [table_version](https://github.com/linz/postgresql-tableversion)
-version 1.4.0 or higher.
+version 1.5.0 or higher.
 
 License
 ---------------------

--- a/test/base.pg
+++ b/test/base.pg
@@ -18,11 +18,11 @@
 
 SET client_min_messages TO WARNING;
 
-CREATE EXTENSION postgis;
-CREATE EXTENSION pgtap;
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS pgtap;
 
-CREATE SCHEMA _patches;
-CREATE EXTENSION dbpatch SCHEMA _patches;
+CREATE SCHEMA IF NOT EXISTS _patches;
+CREATE EXTENSION IF NOT EXISTS dbpatch SCHEMA _patches;
 
 -- Switch to unprivileged role
 DO $$

--- a/test/base.pg
+++ b/test/base.pg
@@ -21,24 +21,6 @@ SET client_min_messages TO WARNING;
 CREATE EXTENSION postgis;
 CREATE EXTENSION pgtap;
 
---VERSIONED-- -- As of table_version 1.4.x the ver_enable_versioning function was
---VERSIONED-- -- not security definer and thus possibly lacked privileges to
---VERSIONED-- -- write in pg_depend.
---VERSIONED-- -- See https://github.com/linz/postgresql-tableversion/issues/100
---VERSIONED-- -- FIXME: drop this or make it conditionally based on
---VERSIONED-- --        table_version version when it'll be fixed
---VERSIONED-- ALTER FUNCTION table_version.ver_enable_versioning(regclass) SECURITY DEFINER;
---VERSIONED-- -- As of table_version 1.4.x the
---VERSIONED-- -- ver_versioned_table_{add,drop}_column functions were
---VERSIONED-- -- not security definers and thus possibly lacked privileges to
---VERSIONED-- -- add/drop columns in the revision tables created by
---VERSIONED-- -- security-definer ver_enable_versioning
---VERSIONED-- -- See https://github.com/linz/postgresql-tableversion/issues/113
---VERSIONED-- -- FIXME: drop this or make it conditionally based on
---VERSIONED-- --        table_version version when it'll be fixed
---VERSIONED-- ALTER FUNCTION table_version.ver_versioned_table_drop_column(name, name, name) SECURITY DEFINER;
---VERSIONED-- ALTER FUNCTION table_version.ver_versioned_table_add_column(name, name, name, text) SECURITY DEFINER;
-
 CREATE SCHEMA _patches;
 CREATE EXTENSION dbpatch SCHEMA _patches;
 

--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -8,6 +8,8 @@ UPGRADEABLE_VERSIONS="
 
 TEST_DATABASE=linz-bde-schema-upgrade-test-db
 
+git fetch --unshallow --tags # to get all commits/tags
+
 TMPDIR=/tmp/linz-bde-schema-test-$$
 mkdir -p ${TMPDIR}
 

--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+UPGRADEABLE_VERSIONS="
+    1.3.0
+    1.2.1
+    1.2.0
+"
+
+TEST_DATABASE=linz-bde-schema-upgrade-test-db
+
+export PGDATABASE=${TEST_DATABASE}
+
+for ver in ${UPGRADEABLE_VERSIONS}; do
+    OWD=$PWD
+
+    dropdb --if-exists ${TEST_DATABASE}
+    createdb ${TEST_DATABASE} || exit 1
+
+    psql -XtA <<EOF
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE SCHEMA IF NOT EXISTS _patches;
+CREATE EXTENSION IF NOT EXISTS dbpatch SCHEMA _patches;
+EOF
+
+    cd /tmp
+    wget -q -O - \
+        https://github.com/linz/linz-bde-schema/archive/${ver}.tar.gz \
+        | tar xzf - && cd linz-bde-schema-${ver} || exit 1
+    sudo env "PATH=$PATH" make install DESTDIR=$PWD/inst || exit 1
+
+    # Install the just-installed linz-bde-schema first !
+    for file in inst/usr/share/linz-bde-schema/sql/*.sql \
+                 inst/usr/share/linz-bde-schema/sql/versioning/*.sql
+    do
+        echo "Loading $file from linz-bde-schema ${ver}"
+        psql -o /dev/null -XtA -f $file ${TEST_DATABASE} --set ON_ERROR_STOP=1 || exit 1
+    done
+
+    cd ${OWD}
+
+    pg_prove test/ || exit 1
+
+done


### PR DESCRIPTION
The PR curently tests upgrads from 1.2.0, 1.2.1 and 1.3.0

Upgrades from 1.1.2 are currently failing so I'm keeping
tis for another time, will file a ticket for that