### PR TITLE
Add upgrade testing from 1.0.1

### DIFF
--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -4,6 +4,7 @@ UPGRADEABLE_VERSIONS="
     1.3.0
     1.2.1
     1.2.0
+    1.0.1
 "
 
 TEST_DATABASE=linz-bde-schema-upgrade-test-db

--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -5,6 +5,7 @@ UPGRADEABLE_VERSIONS="
     1.2.1
     1.2.0
     1.0.1
+    1.0.0
 "
 
 TEST_DATABASE=linz-bde-schema-upgrade-test-db


### PR DESCRIPTION
Note that 1.0.2 added the broken annotations patch, so upgrades
from that function won't work.
See
https://github.com/linz/linz-bde-schema/issues/128#issuecomment-445799591