### PR TITLE
Fix typo resulting in confusing output message about dbpatch loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes for the LINZ BDE schema are documented in this file.
 
 ## 1.7.0dev - 2019-MM-DD
 ### Enhanced
+- Drop confusing output from dbpatch loader preflight call (#146)
 
 ## 1.6.0 - 2019-07-29
 ### Enhanced

--- a/scripts/linz-bde-schema-load.in
+++ b/scripts/linz-bde-schema-load.in
@@ -75,7 +75,7 @@ which $DBPATCH_LOADER > /dev/null || {
 }
 
 # Check if dbpatch-loader supports stdout
-dbpatch-loader - public > /dev/null 2>&2 &&
+dbpatch-loader - fake > /dev/null 2>&1 &&
     DBPATCH_SUPPORTS_STDOUT=yes ||
     DBPATCH_SUPPORTS_STDOUT=no
 


### PR DESCRIPTION
I was fooled by this "loading dbpatch in public schema" message
so went looking and it was due to a typo...