### PR TITLE
Add --readonly switch to schema loader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 sql/05-bde_version.sql
 sql/03-bde_functions.sql
 scripts/linz-bde-schema-load
+scripts/linz-bde-schema-publish
 results/
+test-versioned/
+test-prepared/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes for the LINZ BDE schema are documented in this file.
 ## 1.8.0dev - 2019-MM-DD
 ### Enhanced
 - Lost tables and permissions now recovered upon schema loading (#165)
+### Added
+- Switch --readonly to schema loader (#161)
 
 ## 1.7.0 - 2019-10-09
 ### Added

--- a/scripts/linz-bde-schema-load.in
+++ b/scripts/linz-bde-schema-load.in
@@ -3,7 +3,8 @@
 DB_NAME=
 export SKIP_INDEXES=no
 export ADD_REVISIONS=no
-export EXTENSION_MODE=on
+export EXTENSION_MODE=on # NOTE: "on" is not a typo, it's "on"/"off"
+export READ_ONLY=no
 export PSQL=psql
 export SCRIPTSDIR=/usr/share/linz-bde-schema/sql/
 
@@ -11,6 +12,19 @@ if test "$1" = "--version"; then
     echo "@@VERSION@@ @@REVISION@@"
     exit 0
 fi
+
+usage() {
+    cat <<EOF
+Usage: $0 [options] { <database> | - }
+       $0 { --version | --help }
+Options:
+    --noindexes     skips creation of indexes
+    --revision      enable versioning on tables
+    --noextension   avoid using extension version of dbpatch and tableversion
+    --readonly      revoke write permission on schema from all bde roles
+EOF
+}
+
 
 if test -n "${BDESCHEMA_SQLDIR}"; then
     SCRIPTSDIR=${BDESCHEMA_SQLDIR}
@@ -31,6 +45,11 @@ while test -n "$1"; do
     elif test $1 = "--revision"; then
         ADD_REVISIONS=yes
         shift; continue
+    elif test $1 = "--readonly"; then
+        READ_ONLY=yes
+        shift; continue
+    elif test $1 = "--help"; then
+        usage && exit
     elif test $1 = "--noextension"; then
         EXTENSION_MODE=off
         shift; continue
@@ -40,8 +59,7 @@ while test -n "$1"; do
 done
 
 if test -z "$DB_NAME"; then
-    echo "Usage: $0 [--noindexes] [--revision] [--noextension] { <database> | - }" >&2
-    echo "       $0 --version" >&2
+    usage >&2
     exit 1
 fi
 
@@ -162,6 +180,14 @@ done
 if test "${ADD_REVISIONS}" = "yes"; then
     file=${SCRIPTSDIR}/versioning/01-version_tables.sql
     cat ${file} || rollback
+fi
+
+if test "${READ_ONLY}" = "yes"; then
+    cat <<EOF
+REVOKE UPDATE, INSERT, DELETE, TRUNCATE
+    ON ALL TABLES IN SCHEMA bde
+    FROM bde_dba, bde_admin, bde_user;
+EOF
 fi
 
 echo "COMMIT;"

--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -53,6 +53,13 @@ EOF
 
     cd ${OWD}
 
+# Turn DB to read-only mode, as it would be done
+# by linz-bde-schema-load --readonly
+    cat <<EOF | psql -Xat ${TEST_DATABASE}
+REVOKE UPDATE, INSERT, DELETE, TRUNCATE
+    ON ALL TABLES IN SCHEMA bde
+    FROM bde_dba, bde_admin, bde_user;
+EOF
     pg_prove test/ || exit 1
 
 done

--- a/test/test-upgrades.sh
+++ b/test/test-upgrades.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 UPGRADEABLE_VERSIONS="
+    1.7.0
     1.6.1
     1.6.0
     1.5.0


### PR DESCRIPTION
Closes #161

It revokes insert/update/truncate/delete on bde tables
from `bde_admin`. Leaves it to `bde_dba` at the moment
but maybe we should drop that too...