### PR TITLE
Grant SELECT on table_version.revision_id_seq to bde_dba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes for the LINZ BDE schema are documented in this file.
 
+## 1.9.0dev - 2020-MM-DD
+### Enhanced
+- Grant SELECT on `table_version.revision_id_seq` to `bde_dba` (#170)
+
 ## 1.8.0 - 2019-11-12
 ### Enhanced
 - Lost tables and permissions now recovered upon schema loading (#165)

--- a/sql/versioning/01-version_tables.sql
+++ b/sql/versioning/01-version_tables.sql
@@ -36,6 +36,11 @@ BEGIN
     -- See https://github.com/linz/linz-bde-schema/issues/70
     GRANT CREATE ON SCHEMA table_version TO bde_dba;
 
+	-- It makes sense for bde_dba to also have SELECT permissions
+    -- on sequences in table_version schema
+    -- See https://github.com/linz/linz-bde-schema/issues/170
+    GRANT SELECT ON ALL SEQUENCES IN SCHEMA table_version TO bde_dba;
+
     v_needs_rev := false;
 
     FOR v_schema, v_table IN

--- a/test/base-revision-tables.pg.inc
+++ b/test/base-revision-tables.pg.inc
@@ -1,6 +1,13 @@
 
 -- WARNING: always update this file whenever test/base.pg is updated
 
+-- Test table_version tables permissions {
+
+-- See https://github.com/linz/linz-bde-schema/issues/170
+SELECT sequence_privs_are ( 'table_version'::name, 'revision_id_seq'::name, 'bde_dba'::name, ARRAY['SELECT'] );
+
+-- }
+
 -- Test revision tables existance and their composition {
 
 SELECT has_table('table_version'::name, 'bde_cbe_title_parcel_association_revision'::name);

--- a/test/base.pg
+++ b/test/base.pg
@@ -49,6 +49,7 @@ BEGIN
 --VERSIONED-- --       grant CREATE on table_version to bde_dba (as requested by
 --VERSIONED-- --       sql/versioning/01-version_tables.sql)
 --VERSIONED-- GRANT ALL ON SCHEMA table_version TO linz_bde_schema_test_role WITH GRANT OPTION;
+--VERSIONED-- GRANT SELECT ON ALL SEQUENCES IN SCHEMA table_version TO linz_bde_schema_test_role WITH GRANT OPTION;
     SET session_authorization TO linz_bde_schema_test_role;
 END $$;
 
@@ -65,7 +66,7 @@ END $$;
 BEGIN;
 
 SELECT * FROM plan(653
---VERSIONED-- + 525
+--VERSIONED-- + 526
 );
 
 -- Test base schema existance
@@ -267,6 +268,7 @@ BEGIN
 --VERSIONED-- -- TODO: figure out which "dependent privileges exist", to
 --VERSIONED-- --      replace the CASCADE with fine-grained REVOKEs
 --VERSIONED-- REVOKE ALL ON SCHEMA table_version FROM linz_bde_schema_test_role CASCADE;
+--VERSIONED-- REVOKE ALL ON ALL SEQUENCES IN SCHEMA table_version FROM linz_bde_schema_test_role CASCADE;
     DROP ROLE linz_bde_schema_test_role;
 END; $$;
 


### PR DESCRIPTION
This is not strictly needed for operations but is useful for
consistency and debugging.

Includes testcase.
Closes #170