### PR TITLE
Stop searching for tableversion/dbpatch scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes for the LINZ BDE schema are documented in this file.
 ### Changed
 - Landonline 3.21 support (#180):
  - Add `ver_datum_code` column to `bde.crs_work`
+### Enhanced
+- Stop searching for tableversion/dbpatch scripts, not needed anymore
 
 ## 1.9.0 - 2020-02-11
 ### Enhanced

--- a/scripts/linz-bde-schema-load.in
+++ b/scripts/linz-bde-schema-load.in
@@ -65,19 +65,6 @@ fi
 
 export PGDATABASE=$DB_NAME
 
-# Configure environment for dbpatch-loader
-PGBIN=`pg_config --bindir 2> /dev/null`
-if test -n "$PGBIN"; then
-    PATH=$PATH:$PGBIN
-else
-    # Wild guess where table_version-loader and dbpatch-loader
-    # will be found (as of versions 1.4.0 and 1.2.0 they were
-    # installed in PostgreSQL bin dir)
-    for f in /usr/lib/postgresql/*/bin/; do
-      PATH="$PATH:$f";
-    done
-fi
-
 rollback()
 {
     echo "ROLLBACK;"


### PR DESCRIPTION
It's not needed anymore given our minimum requirements of
tableversion 1.4.0+ and dbpatch 1.2.0+