### PR TITLE
Improvement in package building github action workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - master
       - packagecloud
       - 'release-*'
-    tags:
-      - '*'
+    tags-ignore:
+      - 'debian/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       if: matrix.pg >= 10
 
   package:
-    if: ${{ success() }}
+    needs: test
     name: Package for Debian
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,7 @@ jobs:
         if test "${{ github.event_name }}" = 'push'; then
           if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
             REPO=test
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
           elif test "${{ github.ref }}" = 'refs/heads/packagecloud' \
                  -o "${{ github.ref }}" = 'refs/heads/master'
           then
@@ -154,7 +155,7 @@ jobs:
         echo "REPO: $REPO"
         echo ::set-env name=REPO::"$REPO"
 
-    - uses: linz/linz-software-repository@master
+    - uses: linz/linz-software-repository@v3
       with:
         packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
         publish_to_repository: ${{ env.REPO }}


### PR DESCRIPTION
1. Only build packages if tests were successful.

2. Use linz-software-repository@v3 to automatically push
   debian/changelog updates and debian tag to origin

3. Ignore pushes of debian tags to avoid infinite loops