### PR TITLE
fix: protect_reference column > VARCHAR(255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 All notable changes for the LINZ BDE schema are documented in this file.
 
-## 1.6.2 - 2020-08-22
+## 1.6.2 - 2020-08-31
 ### Fixed
-- Enlarge `crs_title` `protect_reference`
-  column to 255 chars (#209)
+- Enlarge `crs_title` `protect_reference` column to 255 chars (#209)
 
 ## 1.6.1 - 2019-09-09
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes for the LINZ BDE schema are documented in this file.
 
+## 1.6.2 - 2020-08-22
+### Fixed
+- Enlarge `crs_title` `protect_reference`
+  column to 255 chars (#209)
+
 ## 1.6.1 - 2019-09-09
 ### Enhanced
 - Drop confusing output from dbpatch loader preflight call (#146)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Minimal script to install the SQL creation scripts ready for postinst script.
 
-VERSION=1.6.1
+VERSION=1.6.2
 REVISION = $(shell test -d .git && git describe --always || echo $(VERSION))
 
 TEST_DATABASE = regress_linz_bde_schema

--- a/sql/99-patches.sql
+++ b/sql/99-patches.sql
@@ -196,12 +196,12 @@ $P$
 --------------------------------------------------------------------------------
 -- protect_reference column VARCHAR(100) > VARCHAR(255)
 --
--- For tables bde.crs_title
+-- For table bde.crs_title
 -- as per https://github.com/linz/linz-bde-schema/issues/209
 --------------------------------------------------------------------------------
 
 PERFORM _patches.apply_patch(
-    'LOL 3.22: Enlarge crs_title protect_reference column to 255 chars',
+    '[Backport] LOL 3.22: Enlarge crs_title protect_reference column to 255 chars',
     $P$
 DO $$
 DECLARE
@@ -232,7 +232,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- If crs_title is versioned, use table_version API to chnage columns
+  -- If crs_title is versioned, use table_version API to change columns
   IF v_isversioned
   THEN
       PERFORM table_version.ver_versioned_table_change_column_type(

--- a/sql/99-patches.sql
+++ b/sql/99-patches.sql
@@ -193,5 +193,66 @@ $$
 $P$
 );
 
+--------------------------------------------------------------------------------
+-- protect_reference column VARCHAR(100) > VARCHAR(255)
+--
+-- For tables bde.crs_title
+-- as per https://github.com/linz/linz-bde-schema/issues/209
+--------------------------------------------------------------------------------
+
+PERFORM _patches.apply_patch(
+    'LOL 3.22: Enlarge crs_title protect_reference column to 255 chars',
+    $P$
+DO $$
+DECLARE
+  v_versioning_enabled BOOL;
+  v_isversioned BOOL;
+
+BEGIN
+
+  v_versioning_enabled := false;
+  v_isversioned := false;
+
+  -- Is the DB versioned
+  IF EXISTS (SELECT p.oid
+             FROM pg_catalog.pg_proc p, pg_catalog.pg_namespace n
+             WHERE p.proname = 'ver_is_table_versioned'
+             AND n.oid = p.pronamespace
+             AND n.nspname = 'table_version')
+  THEN
+    v_versioning_enabled := true;
+  END IF;
+
+  IF v_versioning_enabled
+  THEN
+    -- Is crs_title is versioned
+    IF table_version.ver_is_table_versioned('bde', 'crs_title')
+    THEN
+      v_isversioned := true;
+    END IF;
+  END IF;
+
+  -- If crs_title is versioned, use table_version API to chnage columns
+  IF v_isversioned
+  THEN
+      PERFORM table_version.ver_versioned_table_change_column_type(
+          'bde',
+          'crs_title',
+          'protect_reference',
+          'VARCHAR(255)'
+      );
+  -- Otherwise use direct ALTER TABLE
+  ELSE
+    ALTER TABLE bde.crs_title
+    ALTER COLUMN protect_reference TYPE VARCHAR(255);
+  END IF;
+
+END;
+$$
+$P$
+);
+
 END;
 $PATCHES$;
+
+


### PR DESCRIPTION
Backport of 12df32d1316531260c24fa0dd23e973a6f66973e

Closes #209 and https://github.com/linz/bde-processor-deployment/issues/899

I had a go at creating a backport for the protect_reference column VARCHAR(100) -> VARCHAR(255) issue for 1.6 branch.
Only doing fix on bde.crs_title table.