### PR TITLE
Release 1.14.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -399,3 +399,4 @@ jobs:
                   release: ${{ matrix.distro }}
                   packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
                   packagecloud_repository: ${{ env.REPO }}
+                  push_to_git_remote: origin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes for the LINZ BDE schema are documented in this file.
 
+## 1.14.1 - 2022-05-02
+
+### Fixed
+
+-   Force pushing changes to origin remote
+
 ## 1.14.0 - 2022-03-08
 
 ### Added

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linz-bde-schema (1.14.1-linz~bionic) bionic; urgency=medium
+
+  * New version
+
+ -- Victor Engmark <vengmark@linz.govt.nz>  Mon, 02 May 2022 02:28:30 +0000
+
 linz-bde-schema (1.14.0-linz~focal) focal; urgency=medium
 
   * New version


### PR DESCRIPTION
linz-software-repository seems to do the wrong thing
<https://github.com/linz/linz-software-repository/issues/113> when
building for more than one release.